### PR TITLE
Fixes #26 recursive cend() with line from above

### DIFF
--- a/include/bpstd/string_view.hpp
+++ b/include/bpstd/string_view.hpp
@@ -1186,7 +1186,7 @@ typename bpstd::basic_string_view<CharT,Traits>::const_iterator
   bpstd::basic_string_view<CharT,Traits>::cend()
   const noexcept
 {
-  return cend();
+  return m_str + m_size;
 }
 
 template <typename CharT, typename Traits>


### PR DESCRIPTION
### Checklist

- [x ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x ] The coding style is consistent with the rest of the library
- [x ] My branch's history is clean and coherent. This could be done through
      at least one of the following practices:
  * Rebasing my branch off of the branch being merged to
  * Squashing commits to create a more cohesive history
- [x ] If relevant, I have included unit-tests (for new code/bugfixes)

----------

### Description

<!--
This fixes a recursive call in the `cend()` function. The exact line of code was used from the `const`-form of the `end()` function preceeding this method.
-->

## GitHub Issues
<!--
This PR is motivated by existing Github Issue #26

It is a simple bug-fix that 'Closes #26'
to your commit message, so that it is automatically closed.

If it is not, don't, as it might take several iterations for a bugfix
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.

If there is no associated Github Issue, please remove this section entirely
-->
